### PR TITLE
ci: use org-level runner variables for shared workflows

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -75,7 +75,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.BUILD_RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -98,7 +98,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DEPLOY_RUNNER || 'ubuntu-latest' }}
     environment: ${{ contains(inputs.container-app-name, 'prod') && 'production' || 'staging' }}
     steps:
       - name: Login to Azure

--- a/.github/workflows/deploy-vps-ssh.yml
+++ b/.github/workflows/deploy-vps-ssh.yml
@@ -57,7 +57,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DEPLOY_RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Changes

- `build-and-push.yml`: `ubuntu-latest` -> `${{ vars.BUILD_RUNNER || 'ubuntu-latest' }}`
- `deploy-azure.yml`: `ubuntu-latest` -> `${{ vars.DEPLOY_RUNNER || 'ubuntu-latest' }}`
- `deploy-vps-ssh.yml`: `ubuntu-latest` -> `${{ vars.DEPLOY_RUNNER || 'ubuntu-latest' }}`

## Current Variable Values

- `BUILD_RUNNER` = `blacksmith-4vcpu-ubuntu-2204` (verified working in kombify-Blog)
- `DEPLOY_RUNNER` = not set (falls back to `ubuntu-latest`)

## Rollback

Clear the org variable to instantly fall back to `ubuntu-latest`.