### PR TITLE
fix(actions): actually remove templated secrets ref from doppler-bootstrap docstring

### DIFF
--- a/.github/actions/doppler-bootstrap/action.yml
+++ b/.github/actions/doppler-bootstrap/action.yml
@@ -13,7 +13,7 @@ description: |
 inputs:
   doppler-token:
     description: |
-      Doppler service token. Pass the value `${{ secrets.DOPPLER_TOKEN }}` (or any other
+      Doppler service token. Pass a Doppler service token from your workflow secrets (or any other
       secret name) — never inline. The action masks the value before any
       command runs.
     required: true


### PR DESCRIPTION
Follow-up to #29 which only changed the surrounding prose but kept the templated literal \${{ secrets.DOPPLER_TOKEN }} intact, so kombify-DB Deploy Migrations is still broken (run 25013571036 still failing with the exact same parser error). This PR actually removes the templated example from the docstring.